### PR TITLE
Allow draft PR links to be clicked

### DIFF
--- a/gh_notifs.py
+++ b/gh_notifs.py
@@ -222,7 +222,7 @@ class HtmlFormatter:
     @staticmethod
     def _li_class(notif: Notification) -> str:
         if notif.pr.status == PRStatus.DRAFT:
-            return "disabled"
+            return "list-group-item-light"
         elif notif.pr.status == PRStatus.CLOSED:
             return "list-group-item-danger"
         else:


### PR DESCRIPTION
The `disabled` class had disabled the links on the element, where `list-group-item-light` will simply dim the text of the element, while still allowing interaction.

Ref: https://getbootstrap.com/docs/5.0/components/list-group/